### PR TITLE
more explicit constraints on MPI plane size (#12)

### DIFF
--- a/gmpi/eval/prepare_fake_data.py
+++ b/gmpi/eval/prepare_fake_data.py
@@ -106,7 +106,7 @@ def main(opt):
         # NOTE: Deep3DFaceRecon can only provide mask and depth of 224x224
         # https://github.com/sicxu/Deep3DFaceRecon_pytorch
         metadata["img_size"] = 224
-    
+
     if config.GMPI.MODEL.STYLEGAN2.torgba_cond_on_pos_enc == "none":
         # Vanilla version. The number of planes must be same in training and evaluation.
         n_mpi_planes = config.GMPI.MPI.n_gen_planes

--- a/gmpi/train.py
+++ b/gmpi/train.py
@@ -411,7 +411,7 @@ def train(rank, world_size, config, master_port, run_dataset):
 
             if discriminator.step > opt.total_iters:
                 break
-            
+
             if rank == 0:
                 total_progress_bar.update(1)
 


### PR DESCRIPTION
This PR adds more explicit constraints on MPI plane sizes. Due to MPI's intrinsic properties, it may not be able to handle large range of camera poses (see #12). We add `assertion` to give clearer error message.