### PR TITLE
Add pretrained checkpoints and preprocessed data to release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd /path/to/this/repo
 export GMPI_ROOT=$PWD
 ```
 
-Please download our [pretrained checkpoints](https://drive.google.com/drive/folders/1MEIjen0XOIW-kxEMfBUONnKYrkRATSR_?usp=sharing) and place them under `${GMPI_ROOT}/ckpts`. The structure should be:
+Please download our pretrained checkpoints from [the release page](https://github.com/apple/ml-gmpi/releases) or [this link](https://drive.google.com/drive/folders/1MEIjen0XOIW-kxEMfBUONnKYrkRATSR_?usp=sharing) and place them under `${GMPI_ROOT}/ckpts`. The structure should be:
 ```
 .
 +-- ckpts

--- a/docs/TRAIN_EVAL.md
+++ b/docs/TRAIN_EVAL.md
@@ -121,7 +121,7 @@ mv ${GMPI_ROOT}/runtime_dataset/metfaces_detect/detections/fail_list.txt ${GMPI_
 
 ### Processed Data
 
-We provide processed poses for FFHQ and Metfaces in [this link](https://drive.google.com/drive/folders/1JDDtGXZP0Z8OwRROO5VNxOjQgwpUSJDj?usp=sharing).
+We provide processed poses for FFHQ and Metfaces in [the release page](https://github.com/apple/ml-gmpi/releases) and [this link](https://drive.google.com/drive/folders/1JDDtGXZP0Z8OwRROO5VNxOjQgwpUSJDj?usp=sharing).
 
 ### Final Folder Structure
 


### PR DESCRIPTION
This PR modified README to point to uploaded checkpoints and preprocssed data on the release page.